### PR TITLE
chore: import files from sis-project (initial merge)

### DIFF
--- a/import-hasan-sis/.gitattributes
+++ b/import-hasan-sis/.gitattributes
@@ -1,0 +1,2 @@
+# Auto detect text files and perform LF normalization
+* text=auto

--- a/import-hasan-sis/CMakeLists.txt
+++ b/import-hasan-sis/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.10)
+project(sis_app)
+
+set(CMAKE_CXX_STANDARD 11)
+
+add_executable(sis_app src/main.cpp)
+target_link_libraries(sis_app pqxx pq)

--- a/import-hasan-sis/Dockerfile
+++ b/import-hasan-sis/Dockerfile
@@ -1,0 +1,10 @@
+FROM ubuntu:22.04
+
+RUN apt-get update && apt-get install -y \
+    g++ cmake make libpqxx-dev
+
+WORKDIR /app
+COPY . .
+
+RUN cmake -S . -B build && cmake --build build
+CMD ["./build/sis_app"]

--- a/import-hasan-sis/docker-compose.yml
+++ b/import-hasan-sis/docker-compose.yml
@@ -1,0 +1,21 @@
+services:
+  db:
+    image: postgres:latest
+    container_name: sis-db
+    environment:
+      POSTGRES_DB: sis
+      POSTGRES_USER: sis_user
+      POSTGRES_PASSWORD: sis_pass
+    volumes:
+      - sis_db_data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+
+  app:
+    build: .
+    container_name: sis-app
+    depends_on:
+      - db
+
+volumes:
+  sis_db_data:

--- a/import-hasan-sis/src/main.cpp
+++ b/import-hasan-sis/src/main.cpp
@@ -1,0 +1,6 @@
+#include <iostream>
+
+int main() {
+    std::cout << "SIS Docker Week 2 OK" << std::endl;
+    return 0;
+}


### PR DESCRIPTION
Initial work from a separate repository (sis-project) was imported into the main
repository under a dedicated folder to preserve all important files and ensure
a single source of truth for the project.
