### PR TITLE
chore: standardize project structure (move files to root)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Auto detect text files and perform LF normalization
+* text=auto

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.10)
+project(sis_app)
+
+set(CMAKE_CXX_STANDARD 11)
+
+add_executable(sis_app src/main.cpp)
+target_link_libraries(sis_app pqxx pq)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM ubuntu:22.04
+
+RUN apt-get update && apt-get install -y \
+    g++ cmake make libpqxx-dev
+
+WORKDIR /app
+COPY . .
+
+RUN cmake -S . -B build && cmake --build build
+CMD ["./build/sis_app"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+services:
+  db:
+    image: postgres:latest
+    container_name: sis-db
+    environment:
+      POSTGRES_DB: sis
+      POSTGRES_USER: sis_user
+      POSTGRES_PASSWORD: sis_pass
+    volumes:
+      - sis_db_data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+
+  app:
+    build: .
+    container_name: sis-app
+    depends_on:
+      - db
+
+volumes:
+  sis_db_data:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,6 @@
+#include <iostream>
+
+int main() {
+    std::cout << "SIS Docker Week 2 OK" << std::endl;
+    return 0;
+}


### PR DESCRIPTION
Copies Dockerfile, docker-compose.yml, CMakeLists, and src from import-hasan-sis
into the repository root to standardize the project structure for Week 3
development. The import folder is kept temporarily for traceability.
